### PR TITLE
Dropping SignalProducer.buffer in MutableProperty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode7.3
 before_install: true
 install: true
 git:

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,3 +1,3 @@
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"
-github "Quick/Quick" ~> 0.8
-github "Quick/Nimble" ~> 3.1
+github "Quick/Quick" ~> 0.9.1
+github "Quick/Nimble" ~> 3.2

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Quick/Nimble" "v3.1.0"
-github "Quick/Quick" "v0.8.0"
+github "Quick/Nimble" "v3.2.0"
+github "Quick/Quick" "v0.9.1"
 github "antitypical/Result" "1.0.2"
 github "jspahrsummers/xcconfigs" "ec5753493605deed7358dec5f9260f503d3ed650"

--- a/ReactiveCocoa/Swift/Action.swift
+++ b/ReactiveCocoa/Swift/Action.swift
@@ -134,7 +134,7 @@ public final class Action<Input, Output, Error: ErrorType> {
 public final class CocoaAction: NSObject {
 	/// The selector that a caller should invoke upon a CocoaAction in order to
 	/// execute it.
-	public static let selector: Selector = "execute:"
+	public static let selector: Selector = #selector(CocoaAction.execute(_:))
 
 	/// Whether the action is enabled.
 	///

--- a/ReactiveCocoa/Swift/Event.swift
+++ b/ReactiveCocoa/Swift/Event.swift
@@ -131,9 +131,9 @@ extension Event: CustomStringConvertible {
 /// Event protocol for constraining signal extensions
 public protocol EventType {
 	// The value type of an event.
-	typealias Value
+	associatedtype Value
 	/// The error type of an event. If errors aren't possible then `NoError` can be used.
-	typealias Error: ErrorType
+	associatedtype Error: ErrorType
 	/// Extracts the event from the receiver.
 	var event: Event<Value, Error> { get }
 }

--- a/ReactiveCocoa/Swift/ObjectiveCBridging.swift
+++ b/ReactiveCocoa/Swift/ObjectiveCBridging.swift
@@ -53,7 +53,7 @@ private func defaultNSError(message: String, file: String, line: Int) -> NSError
 extension RACSignal {
 	/// Creates a SignalProducer which will subscribe to the receiver once for
 	/// each invocation of start().
-	public func toSignalProducer(file: String = __FILE__, line: Int = __LINE__) -> SignalProducer<AnyObject?, NSError> {
+	public func toSignalProducer(file: String = #file, line: Int = #line) -> SignalProducer<AnyObject?, NSError> {
 		return SignalProducer { observer, disposable in
 			let next = { obj in
 				observer.sendNext(obj)
@@ -217,7 +217,7 @@ extension RACCommand {
 	/// Note that the returned Action will not necessarily be marked as
 	/// executing when the command is. However, the reverse is always true:
 	/// the RACCommand will always be marked as executing when the action is.
-	public func toAction(file: String = __FILE__, line: Int = __LINE__) -> Action<AnyObject?, AnyObject?, NSError> {
+	public func toAction(file: String = #file, line: Int = #line) -> Action<AnyObject?, AnyObject?, NSError> {
 		let enabledProperty = MutableProperty(true)
 
 		enabledProperty <~ self.enabled.toSignalProducer()

--- a/ReactiveCocoa/Swift/Optional.swift
+++ b/ReactiveCocoa/Swift/Optional.swift
@@ -9,7 +9,7 @@
 /// An optional protocol for use in type constraints.
 public protocol OptionalType {
 	/// The type contained in the otpional.
-	typealias Wrapped
+	associatedtype Wrapped
 
 	/// Extracts an optional from the receiver.
 	var optional: Wrapped? { get }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -3,7 +3,7 @@ import enum Result.NoError
 
 /// Represents a property that allows observation of its changes.
 public protocol PropertyType {
-	typealias Value
+	associatedtype Value
 
 	/// The current value of the property.
 	var value: Value { get }

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -95,9 +95,11 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// underlying producer prevents sending recursive events.
 	private let lock: NSRecursiveLock
 
-	/// The getter and setter of the underlying storage, which could outlive
-	/// the property if any of the returned producer is being retained.
+	/// The getter of the underlying storage, which may outlive the property
+	/// if a returned producer is being retained.
 	private let getter: () -> Value
+
+	/// The setter of the underlying storage.
 	private let setter: Value -> Void
 
 	/// The current value of the property.

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -95,8 +95,8 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// underlying producer prevents sending recursive events.
 	private let lock: NSRecursiveLock
 
-	/// The getter and setter of the underlying storage. It could outlive
-	/// the property if any of the returned producer is retained.
+	/// The getter and setter of the underlying storage, which could outlive
+	/// the property if any of the returned producer is being retained.
 	private let getter: () -> Value
 	private let setter: Value -> Void
 
@@ -122,7 +122,7 @@ public final class MutableProperty<Value>: MutablePropertyType {
 	/// followed by all changes over time, then complete when the property has
 	/// deinitialized.
 	public var producer: SignalProducer<Value, NoError> {
-		return SignalProducer { [getter, setter, lock, weak self] producerObserver, producerDisposable in
+		return SignalProducer { [getter, lock, weak self] producerObserver, producerDisposable in
 			lock.lock()
 			defer { lock.unlock() }
 
@@ -145,7 +145,6 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		setter = { newValue in value = newValue }
 
 		(signal, observer) = Signal.pipe()
-		observer.sendNext(initialValue)
 	}
 
 	/// Atomically replaces the contents of the variable.

--- a/ReactiveCocoa/Swift/Property.swift
+++ b/ReactiveCocoa/Swift/Property.swift
@@ -144,6 +144,8 @@ public final class MutableProperty<Value>: MutablePropertyType {
 		var value = initialValue
 
 		lock = NSRecursiveLock()
+		lock.name = "org.reactivecocoa.ReactiveCocoa.MutableProperty"
+
 		getter = { value }
 		setter = { newValue in value = newValue }
 

--- a/ReactiveCocoa/Swift/Signal.swift
+++ b/ReactiveCocoa/Swift/Signal.swift
@@ -154,10 +154,10 @@ public final class Signal<Value, Error: ErrorType> {
 
 public protocol SignalType {
 	/// The type of values being sent on the signal.
-	typealias Value
+	associatedtype Value
 	/// The type of error that can occur on the signal. If errors aren't possible
 	/// then `NoError` can be used.
-	typealias Error: ErrorType
+	associatedtype Error: ErrorType
 
 	/// Extracts a signal from the receiver.
 	var signal: Signal<Value, Error> { get }

--- a/ReactiveCocoa/Swift/SignalProducer.swift
+++ b/ReactiveCocoa/Swift/SignalProducer.swift
@@ -289,10 +289,10 @@ private struct BufferState<Value, Error: ErrorType> {
 
 public protocol SignalProducerType {
 	/// The type of values being sent on the producer
-	typealias Value
+	associatedtype Value
 	/// The type of error that can occur on the producer. If errors aren't possible
 	/// then `NoError` can be used.
-	typealias Error: ErrorType
+	associatedtype Error: ErrorType
 
 	/// Extracts a signal producer from the receiver.
 	var producer: SignalProducer<Value, Error> { get }

--- a/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACKVOWrapperSpec.m
@@ -565,7 +565,7 @@ qck_describe(@"rac_addObserver:forKeyPath:options:block:", ^{
 		expect(disposable).notTo(beNil());
 	});
 
-	qck_it(@"automatically stops KVO on subclasses when the target deallocates", ^{
+	qck_context(@"automatically stops KVO on subclasses when the target deallocates", ^{
 		void (^testKVOOnSubclass)(Class targetClass, id observer) = ^(Class targetClass, id observer) {
 			__weak id weakTarget = nil;
 			__weak id identifier = nil;

--- a/ReactiveCocoaTests/Objective-C/RACSequenceSpec.m
+++ b/ReactiveCocoaTests/Objective-C/RACSequenceSpec.m
@@ -86,7 +86,7 @@ qck_describe(@"+sequenceWithHeadBlock:tailBlock:", ^{
 		expect(@(tailInvoked)).to(beTruthy());
 	});
 
-	qck_afterEach(^{
+	qck_context(@"behaves like a sequence", ^{
 		qck_itBehavesLike(RACSequenceExamples, ^{
 			return @{
 				RACSequenceExampleSequence: sequence,

--- a/ReactiveCocoaTests/Swift/ActionSpec.swift
+++ b/ReactiveCocoaTests/Swift/ActionSpec.swift
@@ -33,7 +33,7 @@ class ActionSpec: QuickSpec {
 				scheduler = TestScheduler()
 				action = Action(enabledIf: enabled) { number in
 					return SignalProducer { observer, disposable in
-						executionCount++
+						executionCount += 1
 
 						if number % 2 == 0 {
 							observer.sendNext("\(number)")

--- a/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
+++ b/ReactiveCocoaTests/Swift/ObjectiveCBridgingSpec.swift
@@ -58,8 +58,10 @@ class ObjectiveCBridgingSpec: QuickSpec {
 				var subscriptions = 0
 
 				let racSignal = RACSignal.createSignal { subscriber in
-					subscriber.sendNext(subscriptions++)
+					subscriber.sendNext(subscriptions)
 					subscriber.sendCompleted()
+
+					subscriptions += 1
 
 					return nil
 				}
@@ -151,7 +153,11 @@ class ObjectiveCBridgingSpec: QuickSpec {
 					var subscriptions = 0
 
 					let producer = SignalProducer<NSNumber, NoError>.attempt {
-						return .Success(subscriptions++)
+						defer {
+							subscriptions += 1
+						}
+
+						return .Success(subscriptions)
 					}
 					let racSignal = producer.toRACSignal()
 

--- a/ReactiveCocoaTests/Swift/PropertySpec.swift
+++ b/ReactiveCocoaTests/Swift/PropertySpec.swift
@@ -246,6 +246,23 @@ class PropertySpec: QuickSpec {
 				property.value = 1
 				expect(value) == 1
 			}
+
+			it("should not deadlock on recursive ABA observation") {
+				let propertyA = MutableProperty(0)
+				let propertyB = MutableProperty(0)
+
+				var value: Int?
+				propertyA.producer.startWithNext { _ in
+					propertyB.producer.startWithNext { _ in
+						propertyA.producer.startWithNext { x in value = x }
+					}
+				}
+
+				expect(value) == 0
+
+				propertyA.value = 1
+				expect(value) == 1
+			}
 		}
 
 		describe("AnyProperty") {

--- a/ReactiveCocoaTests/Swift/SchedulerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SchedulerSpec.swift
@@ -151,7 +151,7 @@ class SchedulerSpec: QuickSpec {
 					for _ in 0..<5 {
 						scheduler.schedule {
 							expect(NSThread.isMainThread()) == false
-							value++
+							value += 1
 						}
 					}
 
@@ -183,7 +183,9 @@ class SchedulerSpec: QuickSpec {
 					disposable.innerDisposable = scheduler.scheduleAfter(NSDate(), repeatingEvery: 0.01, withLeeway: 0) {
 						expect(NSThread.isMainThread()) == false
 
-						if ++count == timesToRun {
+						count += 1
+
+						if count == timesToRun {
 							disposable.dispose()
 						}
 					}

--- a/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalProducerSpec.swift
@@ -19,7 +19,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should run the handler once per start()") {
 				var handlerCalledTimes = 0
 				let signalProducer = SignalProducer<String, NSError>() { observer, disposable in
-					handlerCalledTimes++
+					handlerCalledTimes += 1
 
 					return
 				}
@@ -424,7 +424,7 @@ class SignalProducerSpec: QuickSpec {
 			it("should run the operation once per start()") {
 				var operationRunTimes = 0
 				let operation: () -> Result<String, NSError> = {
-					operationRunTimes++
+					operationRunTimes += 1
 
 					return .Success("OperationValue")
 				}
@@ -1160,10 +1160,10 @@ class SignalProducerSpec: QuickSpec {
 						completeB = { observerB.sendCompleted() }
 
 						var a = 0
-						sendA = { observerA.sendNext(a++) }
+						sendA = { observerA.sendNext(a); a += 1 }
 
 						var b = 100
-						sendB = { observerB.sendNext(b++) }
+						sendB = { observerB.sendNext(b); b += 1 }
 
 						outerObserver.sendNext(producerA)
 						outerObserver.sendNext(producerB)
@@ -1978,7 +1978,7 @@ class SignalProducerSpec: QuickSpec {
 					var startedTimes = 0
 
 					let producer = SignalProducer<Int, NoError>.never
-						.on(started: { startedTimes++ })
+						.on(started: { startedTimes += 1 })
 					expect(startedTimes) == 0
 
 					let replayedProducer = producer
@@ -1996,7 +1996,7 @@ class SignalProducerSpec: QuickSpec {
 					var startedTimes = 0
 
 					let producer = SignalProducer<Int, NoError>(value: 0)
-						.on(started: { startedTimes++ })
+						.on(started: { startedTimes += 1 })
 
 					let replayedProducer = producer
 						.replayLazily(1)
@@ -2012,7 +2012,7 @@ class SignalProducerSpec: QuickSpec {
 					var startedTimes = 0
 
 					let producer = SignalProducer<Int, NoError>.empty
-						.on(started: { startedTimes++ })
+						.on(started: { startedTimes += 1 })
 					expect(startedTimes) == 0
 
 					let replayedProducer = producer
@@ -2079,7 +2079,9 @@ class SignalProducerSpec: QuickSpec {
 
 					var deinitValues = 0
 
-					var producer: SignalProducer<Value, NoError>! = SignalProducer(value: Value { deinitValues++ })
+					var producer: SignalProducer<Value, NoError>! = SignalProducer(value: Value {
+						deinitValues += 1
+					})
 					expect(deinitValues) == 0
 
 					var replayedProducer: SignalProducer<Value, NoError>! = producer
@@ -2113,7 +2115,11 @@ extension SignalProducer {
 
 		let operation: () -> Result<Value, Error> = {
 			if operationIndex < resultCount {
-				return results[results.startIndex.advancedBy(operationIndex++)]
+				defer {
+					operationIndex += 1
+				}
+
+				return results[results.startIndex.advancedBy(operationIndex)]
 			} else {
 				fail("Operation started too many times")
 

--- a/ReactiveCocoaTests/Swift/SignalSpec.swift
+++ b/ReactiveCocoaTests/Swift/SignalSpec.swift
@@ -22,7 +22,7 @@ class SignalSpec: QuickSpec {
 			
 			it("should run the generator immediately") {
 				var didRunGenerator = false
-				Signal<AnyObject, NoError> { observer in
+				_ = Signal<AnyObject, NoError> { observer in
 					didRunGenerator = true
 					return nil
 				}


### PR DESCRIPTION
For code reuse purpose, Atomic has been refactored to use pthread_mutex and can be initialised as a recursive mutex.
